### PR TITLE
add code check tools

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,226 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Chromium
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: NextLine
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle:    google
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,81 @@
+Checks: |
+  *bugprone*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-forwarding-reference-overload,
+  -bugprone-exception-escape,
+  clang-analyzer-optin.cplusplus.VirtualCall,
+  clang-analyzer-optin.performance.Padding,
+  -clang-diagnostic-float-equal,
+  cppcoreguidelines-init-variables,
+  cppcoreguidelines-prefer-member-initializer,
+  cppcoreguidelines-pro-type-static-cast-downcast,
+  cppcoreguidelines-slicing,
+  google-*,
+  -google-runtime-references,
+  llvm-include-order,
+  llvm-namespace-comment,
+  misc-definitions-in-headers,
+  misc-misplaced-const,
+  misc-non-copyable-objects,
+  misc-static-assert,
+  misc-throw-by-value-catch-by-reference,
+  misc-throw-by-value-catch-by-reference,
+  misc-uniqueptr-reset-release,
+  misc-unused-parameters,
+  modernize*,
+  -modernize-use-trailing-return-type,
+  -modernize-concat-nested-namespaces,
+  -modernize-return-braced-init-list,
+  -modernize-make-unique,
+  -modernize-type-traits,
+  -modernize-macro-to-enum,
+  *performance*,
+  -performance-unnecessary-value-param,
+  -performance-inefficient-string-concatenation,
+  readability-const-return-type,
+  readability-container-size-empty,
+  readability-delete-null-pointer,
+  readability-else-after-return,
+  readability-implicit-bool-conversion,
+  readability-inconsistent-declaration-parameter-name,
+  readability-make-member-function-const,
+  readability-misplaced-array-index,
+  readability-non-const-parameter,
+  readability-qualified-auto,
+  readability-redundant-function-ptr-dereference,
+  readability-redundant-smartptr-get,
+  readability-redundant-string-cstr,
+  readability-simplify-subscript-expr,
+  readability-static-accessed-through-instance,
+  readability-static-definition-in-anonymous-namespace,
+  readability-string-compare,
+  readability-suspicious-call-argument,
+  readability-uniqueptr-delete-release,
+
+WarningsAsErrors: "*"
+
+CheckOptions:
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
+  # Exclude from scanning as this is an exported symbol used for fuzzing
+  # throughout the code base.
+  - key:             readability-identifier-naming.FunctionIgnoredRegexp
+    value:           "LLVMFuzzerTestOneInput"
+  - key:             readability-identifier-naming.MemberCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ParameterCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.VariableCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.IgnoreMainLikeFunctions
+    value:           1
+  - key:             readability-redundant-member-init.IgnoreBaseInCopyConstructors
+    value:           1
+  - key:             modernize-use-default-member-init.UseAssignment
+    value:           1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+install
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,23 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 include_directories(include)
 
 include(cmake/{{project}}CompileFlags.cmake)
+include(cmake/findAllTarget.cmake)
 
 add_subdirectory(src)
 
-execute_process(
-    COMMAND ${CMAKE_COMMAND} -E create_symlink
-        ${CMAKE_BINARY_DIR}/compile_commands.json
-        /var/tmp/compile_commands.json
-        
+add_custom_target(
+    copy_compile_commands  ALL
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${CMAKE_BINARY_DIR}/compile_commands.json
+    ${CMAKE_SOURCE_DIR}/compile_commands.json
+    COMMENT "Update compile_commands.json" 
 )
+
+get_all_targets(all_targets)
+
+# Loop over all targets and add them as dependencies to AllTargetsDepends
+foreach(target ${all_targets})
+    if(NOT target STREQUAL "copy_compile_commands")  # Exclude the custom target itself
+        add_dependencies(copy_compile_commands ${target})
+    endif()
+endforeach()

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,22 @@
+
+# Don't search for additional CPPLINT.cfg in parent directories.
+set noparent
+
+# The root directory used for deriving header guard CPP variable
+root=include
+
+# exclude specified directories
+exclude_files=thirdparty
+exclude_files=build
+exclude_files=install
+exclude_files=test
+
+
+linelength=120  # As in .clang-format
+
+filter=-build/c++11  # Reports e.g. chrono and thread
+# Requires fundamental change of API, don't see need for this
+filter=-runtime/references  
+
+filter=-legal/copyright
+filter=-readability/todo

--- a/build.sh
+++ b/build.sh
@@ -68,6 +68,7 @@ while getopts ":b:B:ce" opt; do
           ;;
         c)
           rm -rf build install
+          rm -rf compile_commands.json
           echo -e "${YELLOW}------------------------------------------${NC}"
           echo -e "${YELLOW}cleanup success${NC}"
           echo -e "${YELLOW}------------------------------------------${NC}"

--- a/cmake/findAllTarget.cmake
+++ b/cmake/findAllTarget.cmake
@@ -1,0 +1,15 @@
+macro(get_all_targets_recursive targets dir)
+    get_property(subdirectories DIRECTORY ${dir} PROPERTY SUBDIRECTORIES)
+    foreach(subdir ${subdirectories})
+        get_all_targets_recursive(${targets} ${subdir})
+    endforeach()
+
+    get_property(current_targets DIRECTORY ${dir} PROPERTY BUILDSYSTEM_TARGETS)
+    list(APPEND ${targets} ${current_targets})
+endmacro()
+
+function(get_all_targets var)
+    set(targets)
+    get_all_targets_recursive(targets ${CMAKE_CURRENT_SOURCE_DIR})
+    set(${var} ${targets} PARENT_SCOPE)
+endfunction()

--- a/cmake/{{project}}CompileFlags.cmake
+++ b/cmake/{{project}}CompileFlags.cmake
@@ -4,16 +4,14 @@ set(CMAKE_C_FLAGS "-O2 -Wall -Wformat -Wformat=2 -Wconversion -Wimplicit-fallthr
     -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 \
     -D_GLIBCXX_ASSERTIONS \
     -fstack-clash-protection -fstack-protector-strong \
-    -Wl,-z,nodlopen -Wl,-z,noexecstack \
-    -Wl,-z,relro -Wl,-z,now -fdiagnostics-color=always"
+    -fdiagnostics-color=always"
 )
 set(CMAKE_CXX_FLAGS "-O2 -Wall -Wformat -Wformat=2 -Wconversion -Wimplicit-fallthrough\
     -Werror=format-security \
     -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 \
     -D_GLIBCXX_ASSERTIONS \
     -fstack-clash-protection -fstack-protector-strong \
-    -Wl,-z,nodlopen -Wl,-z,noexecstack \
-    -Wl,-z,relro -Wl,-z,now -Wno-reorder -fdiagnostics-color=always"
+    -fdiagnostics-color=always"
 )
 
 

--- a/code_check.sh
+++ b/code_check.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+set -e
+
+
+# Define colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Define text effects
+BOLD='\033[1m'
+UNDERLINE='\033[4m'
+
+lint_check=0
+tidy_check=0
+format_check=0
+
+function pretty_usage() {
+    echo "Usage: $0 [OPTIONS]..."
+    echo
+    echo "Options:"
+    echo "  -l         enable cpplint check."
+    echo "  -t         enable clang-tidy check."
+    echo "  -f         enable clang-format check."
+    echo "  -a         enalble all code check."
+    echo
+    echo "Examples:"
+    echo "  $0 -l -t"
+    exit 1
+}
+
+
+function print_for_test_start() {
+  echo -e "${BLUE}------------------------------------------${NC}"
+  echo "start $1 test."
+  echo -e "${BLUE}------------------------------------------${NC}"
+}
+
+function print_for_test_end() {
+  echo -e "${GREEN}------------------------------------------${NC}"
+    echo "$1 passed."
+    echo -e "${GREEN}------------------------------------------${NC}"
+}
+
+function exit_when_failure() {
+  echo -e "${RED}------------------------------------------${NC}"
+  echo "$1, please check."
+  echo -e "${RED}------------------------------------------${NC}"
+  exit 1
+}
+
+function check_command_existence() {
+    if ! [ -x "$(command -v $1)" ]; then
+        exit_when_failure "$1 isn't installed"
+    fi
+}
+
+# Default values
+cpplint_executable="cpplint"
+dirs_need_check=("include" "src" "test" "example")
+function do_lint_check() {
+    check_command_existence ${cpplint_executable}
+    print_for_test_start ${cpplint_executable}
+    for dir in "${dirs_need_check[@]}"; do
+       ${cpplint_executable} --recursive --quiet ${dir}
+       if [ "$?" -ne 0 ]; then
+           exit_when_failure "${cpplint_executable} for ${dir} failed"
+       fi
+    done
+    print_for_test_end ${cpplint_executable}
+}
+
+clang_tidy_executable="run-clang-tidy"
+compiled_command_database="compile_commands.json"
+function do_tidy_check() {
+  check_command_existence ${clang_tidy_executable}
+  print_for_test_start ${clang_tidy_executable}
+  ## check compiled command database existence or not
+  if [ ! -f "${compiled_command_database}" ]; then
+    ./build.sh
+    if [ "$?" -ne 0 ]; then
+        exit_when_failure "build compile command database failed"
+    fi
+  fi
+  ${clang_tidy_executable} -quiet -p . -j $(($(nproc)/2+1)) ${dirs_need_check[@]}
+  if [ "$?" -ne 0 ]; then
+      exit_when_failure "${clang_tidy_executable} failed, return value $?"
+  fi
+  print_for_test_end ${clang_tidy_executable}
+}
+
+clang_format_executable="clang-format"
+function do_format_check() {
+    check_command_existence ${clang_format_executable}
+    print_for_test_start ${clang_format_executable}
+    find . -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\|c\)' -not -path './build/*' -not -path './install/*' \
+        -exec ${clang_format_executable} --Werror --dry-run --verbose {} \; 
+    if [ "$?" -ne 0 ]; then
+      exit_when_failure "${clang_format_executable} failed, return value $?"
+    fi
+    print_for_test_end ${clang_format_executable}
+}
+
+function do_check() {
+    if [ ${lint_check} = 1 ]; then 
+        do_lint_check
+    fi
+    if [ ${tidy_check} = 1 ]; then 
+        do_tidy_check
+    fi
+    if [ ${format_check} = 1 ]; then 
+        do_format_check
+    fi
+    print_for_test_end "all test passed"
+
+}
+
+while getopts ":lhtfa" opt; do
+    case ${opt} in
+        l)
+          lint_check=1
+          ;;
+        t)
+          tidy_check=1
+          ;;
+        h)
+          pretty_usage
+          ;;
+        f)
+          format_check=1
+          ;;
+        a)
+          format_check=1
+          tidy_check=1
+          lint_check=1
+          ;;
+        *)
+          echo -e "${RED}------------------------------------------${NC}"
+          echo -e "${RED}unsupported operation${NC}"
+          echo -e "${RED}------------------------------------------${NC}"
+          pretty_usage
+          ;;
+    esac
+done
+
+
+
+do_check
+exit 0

--- a/include/{{project}}/{{project}}.hpp
+++ b/include/{{project}}/{{project}}.hpp
@@ -1,5 +1,4 @@
 #ifndef {{project | upper}}_{{project | upper}}_HPP_
 #define {{project | upper}}_{{project | upper}}_HPP_
 
-
 #endif  // {{project | upper}}_{{project | upper}}_HPP_

--- a/src/{{project}}.cpp
+++ b/src/{{project}}.cpp
@@ -1,7 +1,9 @@
 #include "{{project}}/{{project}}.hpp"
 #include <iostream>
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
+  (void)argc;
+  (void)argv;
   std::cout << "hello world\n";
   return 0;
 }


### PR DESCRIPTION
feat: add code check including cpplint, clang-tidy/format
fix: remove unused link parameter that doesn't work for clang-tidy